### PR TITLE
feat(DataType): added bool data-type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - php composer.phar install --dev --prefer-source
 
 script:
-  - php composer.phar test -- --coverage --coverage-xml
+  - XDEBUG_MODE=coverage php composer.phar test -- --coverage --coverage-xml
 
 after_script:
   - php vendor/bin/codacycoverage clover tests/_output/build/coverage/xml

--- a/src/DataType.php
+++ b/src/DataType.php
@@ -11,6 +11,8 @@ class DataType
             return PDO::PARAM_INT;
         } elseif (is_string($value)) {
             return PDO::PARAM_STR;
+        } elseif (is_bool($value)) {
+            return PDO::PARAM_BOOL;
         }
         throw new Exception("'${value}' is not defined data type");
     }


### PR DESCRIPTION
DataTypeにboolを追加した

# 課題

以下のようなコードを書くと、DataTypeがなくてエラーになる。
```php
(new Builder)->where('public', true);
```

# 対策

DataTypeの条件にis_boolを追加して、PDO::PARAM_BOOLに変換する。